### PR TITLE
Remove mocha-as-promised.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   },
   "devDependencies": {
     "bluebird": "^2.3.2",
-    "mocha": ">= 1.4.1",
-    "mocha-as-promised": "latest",
+    "mocha": ">=2.0.1",
     "should": "latest"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,7 +3,6 @@
  * Dependencies
  * --------------------------------------------------------------------------*/
 
-require('mocha-as-promised')();
 var should = require('should'),
     Promise = require('bluebird'),
     mbUtils = require('..');


### PR DESCRIPTION
Although this project is deprecated we're still using it in some of our modules. 
